### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ config = rivergen.ConfigFile("/path/to/config.yaml").export()
 # and plot them for inspection
 for _ in range(10):
     exportpath = rivergen.export_to_file(config)
-    rivergen.test.visualize(exportpath,config)
+    rivergen.tests.visualize(exportpath,config)
 
 
 ```


### PR DESCRIPTION
in `__main__.py`, the following codes import the `tests` module as `tests`.

```python
import rivergen.tests as tests
```

Therefore, to use a function of the `tests` module, `tests.visualize()` should be used. Otherwise, an error message will pop out:

```
AttributeError: module 'rivergen' has no attribute 'test'
```